### PR TITLE
vmm: memory_manager: Only send the GED notification for the ACPI method

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -526,8 +526,7 @@ impl MemoryManager {
         Ok(())
     }
 
-    pub fn resize(&mut self, desired_ram: u64) -> Result<bool, Error> {
-        let mut notify_hotplug = false;
+    pub fn resize(&mut self, desired_ram: u64) -> Result<(), Error> {
         match self.hotplug_method {
             HotplugMethod::VirtioMem => {
                 if desired_ram >= self.boot_ram {
@@ -539,11 +538,10 @@ impl MemoryManager {
                 if desired_ram >= self.current_ram {
                     self.hotplug_ram_region((desired_ram - self.current_ram) as usize)?;
                     self.current_ram = desired_ram;
-                    notify_hotplug = true
                 }
             }
         }
-        Ok(notify_hotplug)
+        Ok(())
     }
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -26,7 +26,7 @@ extern crate vm_allocator;
 extern crate vm_memory;
 extern crate vm_virtio;
 
-use crate::config::{DeviceConfig, VmConfig};
+use crate::config::{DeviceConfig, HotplugMethod, VmConfig};
 use crate::cpu;
 use crate::device_manager::{get_win_size, Console, DeviceManager, DeviceManagerError};
 use crate::memory_manager::{get_host_cpu_phys_bits, Error as MemoryManagerError, MemoryManager};
@@ -550,18 +550,22 @@ impl Vm {
         }
 
         if let Some(desired_memory) = desired_memory {
-            if self
-                .memory_manager
+            self.memory_manager
                 .lock()
                 .unwrap()
                 .resize(desired_memory)
-                .map_err(Error::MemoryManager)?
-            {
-                self.device_manager
-                    .lock()
-                    .unwrap()
-                    .notify_hotplug(HotPlugNotificationFlags::MEMORY_DEVICES_CHANGED)
-                    .map_err(Error::DeviceManager)?;
+                .map_err(Error::MemoryManager)?;
+
+            let memory_config = &self.config.lock().unwrap().memory;
+            match memory_config.hotplug_method {
+                HotplugMethod::Acpi => {
+                    self.device_manager
+                        .lock()
+                        .unwrap()
+                        .notify_hotplug(HotPlugNotificationFlags::MEMORY_DEVICES_CHANGED)
+                        .map_err(Error::DeviceManager)?;
+                }
+                HotplugMethod::VirtioMem => {}
             }
 
             // We update the VM config regardless of the actual guest resize operation


### PR DESCRIPTION
Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>